### PR TITLE
Update logo image style to remove margin

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -10,7 +10,7 @@
 		<a class="logo__link" href="{{ "" | relLangURL }}"{{ with $logoTitle }} title="{{ . }}"{{ end }} rel="home">
 
 			{{ with $logoImage -}}
-				<img src="{{ . | relURL }}" style="height:55px; margin:10px;">
+				<img src="{{ . | relURL }}" style="height:55px;">
             {{- end -}}
 
 		</a>


### PR DESCRIPTION
# What

- マージンの設定を取り除いた

| <img width="417" height="870" alt="image" src="https://github.com/user-attachments/assets/2619c1b7-9de5-44be-939a-d3d5ec5434f0" /> | <img width="422" height="875" alt="image" src="https://github.com/user-attachments/assets/e42c1e71-87dd-4031-882d-1b9d5a3786d5" /> |
| :---: | :---: |
| Before | After |

# Why

- 微調整前のロゴではシンボルとロゴタイプの間隔が広かった
  - おそらくその視覚的調整のためマージンが追加された
  - その結果モバイル版だとロゴがすこし右にずれて表示されていた
- 調整後のロゴでは間隔を狭めたのでマージンは不要になった
  - 幅もぴったりでおさまりがいい