### PR TITLE
fix: アクセシビリティの改善（alt 属性・iframe title・非推奨属性）

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -10,7 +10,7 @@
 		<a class="logo__link" href="{{ "" | relLangURL }}"{{ with $logoTitle }} title="{{ . }}"{{ end }} rel="home">
 
 			{{ with $logoImage -}}
-				<img src="{{ . | relURL }}" style="height:55px;">
+				<img src="{{ . | relURL }}" style="height:55px;" alt="{{ $.Site.Title }} ロゴ">
             {{- end -}}
 
 		</a>

--- a/layouts/partials/member.html
+++ b/layouts/partials/member.html
@@ -11,7 +11,7 @@
     
     <a href = "/authors/{{ urlize $name }}" class = "member_name">
         {{if .Icon}}
-        <img class = "member_icon_img" src="{{ .Icon }}" alt="{{ $name }}">
+        <img class = "member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">
         {{end}}
         {{ $name }}
     </a>

--- a/layouts/partials/member.html
+++ b/layouts/partials/member.html
@@ -11,7 +11,7 @@
     
     <a href = "/authors/{{ urlize $name }}" class = "member_name">
         {{if .Icon}}
-        <img class = "member_icon_img" src="{{ .Icon }}" alt="a">
+        <img class = "member_icon_img" src="{{ .Icon }}" alt="{{ $name }}">
         {{end}}
         {{ $name }}
     </a>

--- a/layouts/partials/post_meta/author.html
+++ b/layouts/partials/post_meta/author.html
@@ -22,7 +22,7 @@
 						{{ range .Members }}
 							{{if eq .Name $title}}
 								{{ if .Icon }}
-								<img class = "member_icon_img" src="{{ .Icon }}" alt="a">
+								<img class = "member_icon_img" src="{{ .Icon }}" alt="{{ $title }}">
 								{{ end }}
 							{{ end }}
 						{{ end }}

--- a/layouts/partials/post_meta/author.html
+++ b/layouts/partials/post_meta/author.html
@@ -22,7 +22,7 @@
 						{{ range .Members }}
 							{{if eq .Name $title}}
 								{{ if .Icon }}
-								<img class = "member_icon_img" src="{{ .Icon }}" alt="{{ $title }}">
+								<img class = "member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">
 								{{ end }}
 							{{ end }}
 						{{ end }}

--- a/layouts/partials/post_meta/members.html
+++ b/layouts/partials/post_meta/members.html
@@ -21,7 +21,7 @@
 						{{ range .Members }}
 							{{if eq .Name $title}}
 								{{ if .Icon }}
-								<img class = "member_icon_img" src="{{ .Icon }}" alt="{{ $title }}">
+								<img class = "member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">
 								{{ end }}
 							{{ end }}
 						{{ end }}

--- a/layouts/partials/post_meta/members.html
+++ b/layouts/partials/post_meta/members.html
@@ -21,7 +21,7 @@
 						{{ range .Members }}
 							{{if eq .Name $title}}
 								{{ if .Icon }}
-								<img class = "member_icon_img" src="{{ .Icon }}" alt="a">
+								<img class = "member_icon_img" src="{{ .Icon }}" alt="{{ $title }}">
 								{{ end }}
 							{{ end }}
 						{{ end }}

--- a/layouts/shortcodes/soundcloud-playlist.html
+++ b/layouts/shortcodes/soundcloud-playlist.html
@@ -3,6 +3,6 @@
   height="300"
   style="overflow:hidden; border:0;"
   allow="autoplay"
-  title="SoundCloud プレイリストプレイヤー"
+  title="SoundCloud プレイリスト {{ index .Params 0 }}"
   src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/{{ index .Params 0 }}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true">
 </iframe>

--- a/layouts/shortcodes/soundcloud-playlist.html
+++ b/layouts/shortcodes/soundcloud-playlist.html
@@ -3,6 +3,6 @@
   height="300"
   style="overflow:hidden; border:0;"
   allow="autoplay"
-  title="SoundCloud プレイリスト {{ index .Params 0 }}"
+  title="{{ .Get "title" | default "SoundCloud プレイリストプレイヤー" }}"
   src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/{{ index .Params 0 }}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true">
 </iframe>

--- a/layouts/shortcodes/soundcloud-playlist.html
+++ b/layouts/shortcodes/soundcloud-playlist.html
@@ -1,8 +1,8 @@
 <iframe
   width="100%"
   height="300"
-  scrolling="no"
-  frameborder="no"
+  style="overflow:hidden; border:0;"
   allow="autoplay"
+  title="SoundCloud プレイリストプレイヤー"
   src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/{{ index .Params 0 }}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true">
 </iframe>

--- a/layouts/shortcodes/soundcloud-track.html
+++ b/layouts/shortcodes/soundcloud-track.html
@@ -2,6 +2,6 @@
 height="166"
 style="overflow:hidden; border:0;"
 allow="autoplay"
-title="SoundCloud トラックプレイヤー"
+title="SoundCloud トラック {{ index .Params 0 }}"
 src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/{{ index .Params 0 }}&color=%231c1511&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
 ></iframe>

--- a/layouts/shortcodes/soundcloud-track.html
+++ b/layouts/shortcodes/soundcloud-track.html
@@ -1,7 +1,7 @@
-<iframe width="100%" 
-height="166" 
-scrolling="no" 
-frameborder="no" 
-allow="autoplay" 
+<iframe width="100%"
+height="166"
+style="overflow:hidden; border:0;"
+allow="autoplay"
+title="SoundCloud トラックプレイヤー"
 src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/{{ index .Params 0 }}&color=%231c1511&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
 ></iframe>

--- a/layouts/shortcodes/soundcloud-track.html
+++ b/layouts/shortcodes/soundcloud-track.html
@@ -2,6 +2,6 @@
 height="166"
 style="overflow:hidden; border:0;"
 allow="autoplay"
-title="SoundCloud トラック {{ index .Params 0 }}"
+title="{{ .Get "title" | default "SoundCloud トラックプレイヤー" }}"
 src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/{{ index .Params 0 }}&color=%231c1511&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
 ></iframe>

--- a/layouts/shortcodes/soundcloud-user.html
+++ b/layouts/shortcodes/soundcloud-user.html
@@ -3,6 +3,6 @@
   height="450"
   style="overflow:hidden; border:0;"
   allow="autoplay"
-  title="SoundCloud ユーザープレイヤー"
+  title="SoundCloud ユーザー {{ index .Params 0 }}"
   src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/users/{{ index .Params 0 }}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true">
 </iframe>

--- a/layouts/shortcodes/soundcloud-user.html
+++ b/layouts/shortcodes/soundcloud-user.html
@@ -1,8 +1,8 @@
 <iframe
   width="100%"
   height="450"
-  scrolling="no"
-  frameborder="no"
+  style="overflow:hidden; border:0;"
   allow="autoplay"
+  title="SoundCloud ユーザープレイヤー"
   src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/users/{{ index .Params 0 }}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true">
 </iframe>

--- a/layouts/shortcodes/soundcloud-user.html
+++ b/layouts/shortcodes/soundcloud-user.html
@@ -3,6 +3,6 @@
   height="450"
   style="overflow:hidden; border:0;"
   allow="autoplay"
-  title="SoundCloud ユーザー {{ index .Params 0 }}"
+  title="{{ .Get "title" | default "SoundCloud ユーザープレイヤー" }}"
   src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/users/{{ index .Params 0 }}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true">
 </iframe>

--- a/layouts/taxonomy/author.html
+++ b/layouts/taxonomy/author.html
@@ -17,7 +17,7 @@
 				{{ range .Members }}
 					{{ if eq .Name $title }}
 						{{ if .Icon}}
-							<img class = "author_icon_img" src="{{.Icon}}" alt="{{ $title }}">
+							<img class = "author_icon_img" src="{{.Icon}}" alt="">
 						{{ end }}
 					{{ end }}
 				{{ end }}

--- a/layouts/taxonomy/author.html
+++ b/layouts/taxonomy/author.html
@@ -17,7 +17,7 @@
 				{{ range .Members }}
 					{{ if eq .Name $title }}
 						{{ if .Icon}}
-							<img class = "author_icon_img" src="{{.Icon}}" alt="">
+							<img class = "author_icon_img" src="{{.Icon}}" alt="{{ $title }}">
 						{{ end }}
 					{{ end }}
 				{{ end }}


### PR DESCRIPTION
## 概要

Issue #297 の対応です。スクリーンリーダーユーザーへのアクセシビリティを改善します。

## 変更内容

- `layouts/partials/logo.html`: `<img>` に `alt="{{ $.Site.Title }} ロゴ"` を追加
- `layouts/partials/member.html` / `post_meta/author.html` / `post_meta/members.html`: `alt="a"` → `alt="" aria-hidden="true"` に変更（アイコンは装飾目的のため、同リンク内のテキストと重複しないよう空 alt + aria-hidden で処理）
- `layouts/taxonomy/author.html`: `alt=""` のまま維持（見出し直後にテキストがあるため）
- `layouts/shortcodes/soundcloud-*.html`:
  - `title` named param を追加（`{{< soundcloud-track 123 title="曲名" >}}` のように指定可能）
  - 未指定時は説明的な固定文言にフォールバック
  - 非推奨の `scrolling="no"` / `frameborder="no"` を `style="overflow:hidden; border:0;"` に置換

## テスト計画

- [ ] ロゴ画像の alt テキストが正しく表示されること
- [ ] メンバーアイコン画像がスクリーンリーダーでスキップされること（aria-hidden）
- [ ] SoundCloud 埋め込みの iframe に title 属性が設定されること
- [ ] `title` param を指定すると iframe title に反映されること
- [ ] 既存の1引数呼び出し（`{{< soundcloud-track 123 >}}`）が引き続き動作すること
- [ ] SoundCloud プレイヤーが正常に動作すること

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)