### PR TITLE
fix: CDN リソースへの SRI 属性追加・jQuery 二重読み込み解消

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -72,15 +72,15 @@
 	{{- end }}
 
 <!-- swiper js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/js/swiper.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/js/swiper.min.js" integrity="sha512-E9ezH29tutgGF9ZEFg43IK/1B0rRriQm5oHCG5HyrJHAInBnZPOgoRcnsinWZ+/QcVRiatdpXrdBZQhzpbz7Rw==" crossorigin="anonymous"></script>
 
 <!-- swiper css -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/css/swiper.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/css/swiper.min.css" integrity="sha512-NK1a+fwVgHnWk57liCcVd4/Cm9meSmYYY130YqQ3fEOD7gw3GQ36UJ+CZWVfpM/CtE08YkpIg4MBGzwNG2P3SQ==" crossorigin="anonymous">
 
 <!-- 画像ポップアップ用 -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet">
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" type="text/javascript"></script>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet" integrity="sha512-n/NKfgu/ornW6hzAcIqm6S9VF9Ms57qLjg8dq/7rDj48oeuTeJAawUM0mEXbuDMGLH2Bw+4fWZae/1qXuut68Q==" crossorigin="anonymous">
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha512-U6K1YLIFUWcvuw5ucmMtT9HH4t0uz3M366qrF5y4vnyH6dgDzndlcGvH/Lz5k8NFh80SN95aJ5rqGZEdaQZ7ZQ==" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" integrity="sha512-lMeVFaY2AMSYRjkeBdn0JOhyZ5rL3//wohEwpuE0iZHOmzJlAOWMUayhcJlfomIHyqdvENcFZyCgMbGdD53OfQ==" crossorigin="anonymous"></script>
 
 </head>
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -71,16 +71,16 @@
 		{{- end }}
 	{{- end }}
 
-<!-- swiper js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/js/swiper.min.js" integrity="sha512-E9ezH29tutgGF9ZEFg43IK/1B0rRriQm5oHCG5HyrJHAInBnZPOgoRcnsinWZ+/QcVRiatdpXrdBZQhzpbz7Rw==" crossorigin="anonymous"></script>
+	<!-- swiper js -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/js/swiper.min.js" integrity="sha512-E9ezH29tutgGF9ZEFg43IK/1B0rRriQm5oHCG5HyrJHAInBnZPOgoRcnsinWZ+/QcVRiatdpXrdBZQhzpbz7Rw==" crossorigin="anonymous"></script>
 
-<!-- swiper css -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/css/swiper.min.css" integrity="sha512-NK1a+fwVgHnWk57liCcVd4/Cm9meSmYYY130YqQ3fEOD7gw3GQ36UJ+CZWVfpM/CtE08YkpIg4MBGzwNG2P3SQ==" crossorigin="anonymous">
+	<!-- swiper css -->
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/css/swiper.min.css" integrity="sha512-NK1a+fwVgHnWk57liCcVd4/Cm9meSmYYY130YqQ3fEOD7gw3GQ36UJ+CZWVfpM/CtE08YkpIg4MBGzwNG2P3SQ==" crossorigin="anonymous">
 
-<!-- 画像ポップアップ用 -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet" integrity="sha512-n/NKfgu/ornW6hzAcIqm6S9VF9Ms57qLjg8dq/7rDj48oeuTeJAawUM0mEXbuDMGLH2Bw+4fWZae/1qXuut68Q==" crossorigin="anonymous">
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha512-U6K1YLIFUWcvuw5ucmMtT9HH4t0uz3M366qrF5y4vnyH6dgDzndlcGvH/Lz5k8NFh80SN95aJ5rqGZEdaQZ7ZQ==" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" integrity="sha512-lMeVFaY2AMSYRjkeBdn0JOhyZ5rL3//wohEwpuE0iZHOmzJlAOWMUayhcJlfomIHyqdvENcFZyCgMbGdD53OfQ==" crossorigin="anonymous"></script>
+	<!-- 画像ポップアップ用 -->
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet" integrity="sha512-n/NKfgu/ornW6hzAcIqm6S9VF9Ms57qLjg8dq/7rDj48oeuTeJAawUM0mEXbuDMGLH2Bw+4fWZae/1qXuut68Q==" crossorigin="anonymous">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha512-U6K1YLIFUWcvuw5ucmMtT9HH4t0uz3M366qrF5y4vnyH6dgDzndlcGvH/Lz5k8NFh80SN95aJ5rqGZEdaQZ7ZQ==" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" integrity="sha512-lMeVFaY2AMSYRjkeBdn0JOhyZ5rL3//wohEwpuE0iZHOmzJlAOWMUayhcJlfomIHyqdvENcFZyCgMbGdD53OfQ==" crossorigin="anonymous"></script>
 
 </head>
 

--- a/layouts/shortcodes/load-photoswipe.html
+++ b/layouts/shortcodes/load-photoswipe.html
@@ -9,10 +9,8 @@ Documentation and licence at https://github.com/liwenyip/hugo-easy-gallery/
 
 <!--
 *** jQuery must be loaded before load-photoswipe.js ***
-- If your template already loads jQuery in the header then you don't need to load it again here.
-- If your template already loads jQuery in the footer, then you could load load-photoswipe.js from the footer instead
+- jQuery is already loaded in baseof.html, so we don't need to load it again here.
 -->
-<script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
 <script src={{ "js/load-photoswipe.js" | relURL }}></script>
 
 <!-- Photoswipe css/js libraries -->


### PR DESCRIPTION
## 概要

close #294

- `layouts/_default/baseof.html` の CDN リソース（Swiper / Lightbox2 / jQuery）に `integrity` / `crossorigin` 属性を追加
- `layouts/shortcodes/load-photoswipe.html` の jQuery 重複読み込みを削除（`baseof.html` で既に読み込まれているため）

## 変更内容

- `baseof.html`: Swiper JS/CSS・Lightbox2 JS/CSS・jQuery に SRI ハッシュ（sha512）を追加
- `load-photoswipe.html`: jQuery の重複読み込み行を削除

## テスト計画

- [ ] ローカルビルドで Swiper・Lightbox2 が正常動作することを確認
- [ ] PhotoSwipe を使用しているページで画像ポップアップが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)