### PR TITLE
fix: ビルド失敗時のデプロイを防止する条件を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   deploy:
     runs-on: self-hosted
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Create Temporary Directory
         id: create_temp_dir


### PR DESCRIPTION
## 概要

Close #298

`workflow_run` トリガーでは Build ワークフローが失敗した場合でもデプロイが実行される問題を修正します。

## 変更内容

- `.github/workflows/deploy.yml` の `deploy` ジョブに `if` 条件を追加
  - `workflow_dispatch`（手動実行）の場合は常に実行
  - `workflow_run` トリガーの場合は Build の conclusion が `success` のときのみ実行

## テスト計画

- [ ] Build が成功した後に Deploy ワークフローが実行されることを確認
- [ ] Build が失敗した場合に Deploy ワークフローがスキップされることを確認
- [ ] `workflow_dispatch` による手動デプロイが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)