### PR TITLE
fix: レンダリングブロック解消・Google Fonts 最適化

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,7 +42,7 @@
 	<meta name="description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{ else }}{{ .Params.Description }}{{ end }}">
 
 
-	{{- $googleFontsLink := .Site.Params.googleFontsLink | default "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" }}
+	{{- $googleFontsLink := .Site.Params.googleFontsLink | default "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400&display=swap" }}
 	{{- if hasPrefix $googleFontsLink "https://fonts.googleapis.com/" }}
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link rel="dns-prefetch" href="//fonts.googleapis.com">
@@ -71,16 +71,11 @@
 		{{- end }}
 	{{- end }}
 
-<!-- swiper js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/js/swiper.min.js"></script>
+	<!-- swiper css -->
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/css/swiper.min.css">
 
-<!-- swiper css -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/css/swiper.min.css">
-
-<!-- 画像ポップアップ用 -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet">
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" type="text/javascript"></script>
+	<!-- 画像ポップアップ用 -->
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet">
 
 </head>
 
@@ -102,6 +97,11 @@
 		{{ partial "footer" . }}
 	</div>
 <script async defer src="{{ "js/menu.js" | relURL }}"></script>
+<!-- swiper js -->
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/js/swiper.min.js"></script>
+<!-- jQuery + Lightbox2（Lightbox2 は jQuery に依存するため順序を維持） -->
+<script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js"></script>
 {{ range .Site.Params.customJS -}}
 <script src="{{ . | relURL }}"></script>
 {{- end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -103,7 +103,7 @@
 <script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js"></script>
 {{ range .Site.Params.customJS -}}
-<script src="{{ . | relURL }}"></script>
+<script defer src="{{ . | relURL }}"></script>
 {{- end }}
 {{- partial "mathjax.html" . -}}
 </body>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -96,7 +96,7 @@
 		</div>
 		{{ partial "footer" . }}
 	</div>
-<script async defer src="{{ "js/menu.js" | relURL }}"></script>
+<script defer src="{{ "js/menu.js" | relURL }}"></script>
 <!-- swiper js -->
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.5.0/js/swiper.min.js"></script>
 <!-- jQuery + Lightbox2（Lightbox2 は jQuery に依存するため順序を維持） -->


### PR DESCRIPTION
## 概要

Close #296

`<head>` 内で同期的に読み込まれていた JS ファイルを `</body>` 直前に移動し、`defer` 属性を追加することでレンダリングブロックを解消します。また Google Fonts の読み込みを最適化します。

## 変更内容

### `layouts/_default/baseof.html`

- **JS を body 末尾へ移動 + `defer` 追加**: Swiper JS・jQuery・Lightbox2 JS を `</body>` 直前に移動
  - `defer` により HTML パース完了後に順序通り実行（jQuery → Lightbox2 の依存関係を維持）
- **CSS は head 内に残す**: Swiper CSS・Lightbox2 CSS は head 内に整理（FOUC 防止）
- **Google Fonts 最適化**: API v1 → v2 へ更新、`display=swap` を追加して FOIT を防止

## 期待される効果

- First Contentful Paint (FCP) の短縮
- フォント読み込み中のテキスト非表示（FOIT）の解消

## テスト計画

- [ ] トップページでスライダー（Swiper）が正常に動作することを確認
- [ ] 記事ページで画像クリック時に Lightbox が正常に表示されることを確認
- [ ] フォントが正常に読み込まれることを確認
- [ ] モバイルでも動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)