### PR TITLE
fix: モバイルでメニューボタンのテキストが右寄りになる問題を修正

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -25,6 +25,13 @@
 }
 
 
+/* モバイルでメニューボタンのテキストが右寄りになる問題を修正 */
+@media screen and (max-width: 500px) {
+	.menu__btn-title {
+		text-align: left;
+	}
+}
+
 /* サムネイルサイズ調整 */
 .list__thumbnail img {
     width: 150px;


### PR DESCRIPTION
## 概要

Close #170

モバイル表示時にメニューボタンのラベルテキストが右寄りになる問題を修正します。

## 原因

テーマ CSS（`assets/css/custom.css`）の `.menu__btn-title` に `text-align: right` が設定されており、デスクトップ（`min-width: 500px`）ではメニューボタン自体が非表示になるため問題ないが、モバイル（`max-width: 500px`）では「メニュー」テキストが右寄りで表示される。

## 対応

`static/css/style.css`（テーマ CSS の上書きファイル）にモバイル用の `text-align: left` オーバーライドを追加。

## テスト計画

- [ ] モバイル幅（500px 以下）でトップページを開き、メニューボタンのテキストが左寄りになっていることを確認
- [ ] デスクトップ幅では表示に変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)