### PR TITLE
A4画像の上下が見切れていたバグを修正

### DIFF
--- a/static/css/hugo-easy-gallery-size-A4.css
+++ b/static/css/hugo-easy-gallery-size-A4.css
@@ -17,7 +17,7 @@ Grid Layout Styles
     position: relative;
     /* Default: 1 tile wide */
     width: 100%;
-    padding-bottom: 100%; 
+    padding-bottom: 100%;
 }
 @media only screen and (min-width : 365px) {
     /* Tablet view: 2 tiles */
@@ -45,7 +45,7 @@ Grid Layout Styles
 Transition styles
 */
 .gallery.hover-transition figure,
-.gallery.hover-effect-zoom .img, 
+.gallery.hover-effect-zoom .img,
 .gallery:not(.caption-effect-appear) figcaption,
 .fancy-figure:not(.caption-effect-appear) figcaption {
     -webkit-transition: all 0.3s ease-in-out;
@@ -66,6 +66,7 @@ figure {
     right: 5px;
     top: 5px;
     bottom: 5px;
+    margin: 0;
 }
 .gallery.hover-effect-grow figure:hover {
     transform: scale(1.05);


### PR DESCRIPTION
## 概要
- A4画像の上下が見切れていたバグを修正した

## 原因
- 常時figureにかかっているcustom.cssと競合していたのが原因

## 対処
- A4用のcssにmarginを一旦0にする処理を追記

## 写真
| before | after |
| --- | --- |
| <img width="671" height="680" alt="image" src="https://github.com/user-attachments/assets/8f10959d-2713-4fb7-9796-11d269723e6b" /> | <img width="604" height="616" alt="image" src="https://github.com/user-attachments/assets/7a0db3ec-64dc-4ba8-92e2-67a1e08dbcd1" /> |
