### PR TITLE
fix: HTTP URL を HTTPS に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![workflow](https://github.com/nitmic/nitmic.club.nitech.ac.jp/actions/workflows/deploy.yml/badge.svg)
 ![workflow](https://github.com/nitmic/nitmic.club.nitech.ac.jp/actions/workflows/disk_space_alert.yml/badge.svg)
 
-URL：http://nitmic.club.nitech.ac.jp/
+URL：https://nitmic.club.nitech.ac.jp/
 
 ## Overview
 

--- a/content/post/circle-info-session-2022/index.md
+++ b/content/post/circle-info-session-2022/index.md
@@ -11,7 +11,7 @@ menu: "false"
 aliases: "0011"
 ---
 
-こんにちは、2022NITMic 代表の [dokudami](http://nitmic.club.nitech.ac.jp/authors/dokudami/) です。
+こんにちは、2022NITMic 代表の [dokudami](https://nitmic.club.nitech.ac.jp/authors/dokudami/) です。
 
 ### 合同サークル説明会（オンライン）！
 
@@ -49,4 +49,4 @@ NITMic にご興味を持っていただき、入部をご検討されている�
 
 ※入部案内が届かない場合、迷惑メールとして処理されている可能性があるので、ご確認ください。
 
-> [➡ 入部ページ](http://nitmic.club.nitech.ac.jp/top/join/)
+> [➡ 入部ページ](https://nitmic.club.nitech.ac.jp/top/join/)


### PR DESCRIPTION
## 概要

Close #327

README と記事内に残っていた  の URL を  に統一します。

## 変更内容

-  のサイト URL を HTTPS に修正
-  内の 2 箇所の URL を HTTPS に修正

## 補足

PR #303 から URL 修正だけを切り出した独立 PR です。