### PR TITLE
fix: Google Fonts の読み込みを最適化

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -47,7 +47,7 @@
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link rel="dns-prefetch" href="//fonts.googleapis.com">
 	<link rel="dns-prefetch" href="//fonts.gstatic.com">
-	<link rel="stylesheet" {{ printf `href="%s"` $googleFontsLink | safeHTMLAttr }}>
+	<link rel="stylesheet" href="{{ $googleFontsLink }}">
 	{{- end }}
 
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,7 +42,7 @@
 	<meta name="description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{ else }}{{ .Params.Description }}{{ end }}">
 
 
-	{{- $googleFontsLink := .Site.Params.googleFontsLink | default "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" }}
+	{{- $googleFontsLink := .Site.Params.googleFontsLink | default "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400&display=swap" }}
 	{{- if hasPrefix $googleFontsLink "https://fonts.googleapis.com/" }}
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link rel="dns-prefetch" href="//fonts.googleapis.com">


### PR DESCRIPTION
## 概要

Close #339

Google Fonts の読み込みを API v2 + `display=swap` ベースに更新して、フォント読み込み中の不可視テキストを減らします。

## 変更内容

- Google Fonts のデフォルト URL を API v2 に変更
- `display=swap` を追加

## 補足

PR #308 から Google Fonts 最適化だけを切り出した独立 PR です。
