### PR TITLE
fix: authorの先頭が強制的に大文字になるバグを修正

### DIFF
--- a/layouts/partials/post_meta/author.html
+++ b/layouts/partials/post_meta/author.html
@@ -1,38 +1,31 @@
-
 <!-- 筆者 -->
 {{- $taxo := "authors" -}}
 {{- with .Param $taxo -}}
 <div class="meta__item-author meta__item">
-	<!--
-	{{- partial "svg/author.svg" (dict "class" "meta__icon") -}}
-	-->
 	<span class="meta__text">
 
 		{{- range $index, $author := . }}
-			{{- $url := urls.Parse ($author | urlize) -}}
-			{{- $path := $url.Path -}}
-			{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path) }}
-			<!--
-				{{- if gt $index 0 }}, {{ end -}}
-			-->
-				{{ $title := .Title}}
-				{{if eq $index 0}}
-				<a class="meta__link" href="{{ .RelPermalink }}" rel="category">
-					{{ range hugo.Data.member }}
-						{{ range .Members }}
-							{{if eq .Name $title}}
-								{{ if .Icon }}
-								<img class = "member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">
-								{{ end }}
-							{{ end }}
-						{{ end }}
-					{{ end }}	
-					{{ .Title }}
-				</a>
-				{{end}}
-			{{- end }}
+		{{- $url := urls.Parse ($author | urlize) -}}
+		{{- $path := $url.Path -}}
+		{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path) }}
+		{{- $term := .Data.Term -}}
+		{{- if eq $index 0 }}
+		<a class="meta__link" href="{{ .RelPermalink }}" rel="category">
+			{{ range hugo.Data.member }}
+			{{ range .Members }}
+			{{ if eq .Name $term }}
+			{{ if .Icon }}
+			<img class="member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">
+			{{ end }}
+			{{ end }}
+			{{ end }}
+			{{ end }}
+			{{ $term }}
+		</a>
 		{{- end }}
-		
+		{{- end }}
+		{{- end }}
+
 	</span>
 </div>
 {{- end }}

--- a/layouts/partials/post_meta/members.html
+++ b/layouts/partials/post_meta/members.html
@@ -2,36 +2,29 @@
 {{- $taxo := "authors" -}}
 {{- with .Param $taxo -}}
 <div class="meta__item-author meta__item">
-	<!--
-	{{- partial "svg/author.svg" (dict "class" "meta__icon") -}}
-	-->
 	<span class="meta__text">
 
 		{{- range $index, $author := . }}
-			{{- $url := urls.Parse ($author | urlize) -}}
-			{{- $path := $url.Path -}}
-			{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path) }}
-			<!--
-				{{- if gt $index 0 }}, {{ end -}}
-			-->
-				{{ $title := .Title}}
-				{{if ne $index -1}}
-				<a class="meta__link" href="{{ .RelPermalink }}" rel="category">
-					{{ range hugo.Data.member }}
-						{{ range .Members }}
-							{{if eq .Name $title}}
-								{{ if .Icon }}
-								<img class = "member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">
-								{{ end }}
-							{{ end }}
-						{{ end }}
-					{{ end }}	
-					{{ .Title }}
-				</a>
-				{{end}}
+		{{- if gt $index 0 }}  {{ end -}}
+		{{- $url := urls.Parse ($author | urlize) -}}
+		{{- $path := $url.Path -}}
+		{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path) }}
+		{{- $term := .Data.Term -}}
+		<a class="meta__link" href="{{ .RelPermalink }}" rel="category">
+			{{- range hugo.Data.member }}
+			{{- range .Members }}
+			{{- if eq (lower .Name) (lower $term) }}
+			{{- if .Icon }}
+			<img class="member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">&nbsp;
 			{{- end }}
+			{{- end }}
+			{{- end }}
+			{{- end }}
+			{{- $term -}}
+		</a>
 		{{- end }}
-		
+		{{- end }}
+
 	</span>
 </div>
 {{- end }}

--- a/layouts/taxonomy/author.html
+++ b/layouts/taxonomy/author.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <main class="main list" role="main">
 
-	{{ $title := .Title }}
+	{{ $title := $.Data.Term }}
 	{{ $member := hugo.Data.member }}
 
 

--- a/layouts/taxonomy/author.html
+++ b/layouts/taxonomy/author.html
@@ -3,27 +3,27 @@
 
 	{{ $title := .Title }}
 	{{ $member := hugo.Data.member }}
-	
+
 
 	{{- with .Title }}
 	<header class="main__header">
 		<h1 class="main__title">
-			
+
 			<!--
 				{{- partial "svg/author.svg" (dict "class" "meta__icon") -}}
 			-->
 
 			{{ range $member }}
 				{{ range .Members }}
-					{{ if eq .Name $title }}
+					{{ if eq .Name $.Data.Term }}
 						{{ if .Icon}}
 							<img class = "author_icon_img" src="{{.Icon}}" alt="">
 						{{ end }}
 					{{ end }}
 				{{ end }}
 			{{ end }}
-	
-			{{ . }}
+
+			{{ $.Data.Term }}
 		</h1>
 	</header>
 	{{- end }}


### PR DESCRIPTION
## 概要

- hugoのバージョンがあがった影響でautthorの先頭1文字が強制的に大文字になるバグがあったので直した

## 写真
- **before**
    - > <img width="746" height="109" alt="image" src="https://github.com/user-attachments/assets/8f3f5320-d581-4f50-a1a0-202dee665f71" />
- **after**
    - > <img width="740" height="112" alt="image" src="https://github.com/user-attachments/assets/c0be06c2-c35f-4af9-9981-113757ed3862" />

