### PR TITLE
サイトタイトルが先頭文字が強制大文字になる問題へ再対処

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,9 @@ noTimes = true
 hasCJKLanguage = true
 summaryLength = 130
 
+#  自動リストタイトルを大文字にするのを防ぐ
+capitalizeListTitles = false
+
 [services]
   [services.googleAnalytics]
     id = "" # Enable Google Analytics by entering your tracking id

--- a/layouts/partials/post_meta/author.html
+++ b/layouts/partials/post_meta/author.html
@@ -1,31 +1,38 @@
+
 <!-- 筆者 -->
 {{- $taxo := "authors" -}}
 {{- with .Param $taxo -}}
 <div class="meta__item-author meta__item">
+	<!--
+	{{- partial "svg/author.svg" (dict "class" "meta__icon") -}}
+	-->
 	<span class="meta__text">
 
 		{{- range $index, $author := . }}
-		{{- $url := urls.Parse ($author | urlize) -}}
-		{{- $path := $url.Path -}}
-		{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path) }}
-		{{- $term := .Data.Term -}}
-		{{- if eq $index 0 }}
-		<a class="meta__link" href="{{ .RelPermalink }}" rel="category">
-			{{ range hugo.Data.member }}
-			{{ range .Members }}
-			{{ if eq .Name $term }}
-			{{ if .Icon }}
-			<img class="member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">
-			{{ end }}
-			{{ end }}
-			{{ end }}
-			{{ end }}
-			{{ $term }}
-		</a>
+			{{- $url := urls.Parse ($author | urlize) -}}
+			{{- $path := $url.Path -}}
+			{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path) }}
+			<!--
+				{{- if gt $index 0 }}, {{ end -}}
+			-->
+				{{ $title := .Title}}
+				{{if eq $index 0}}
+				<a class="meta__link" href="{{ .RelPermalink }}" rel="category">
+					{{ range hugo.Data.member }}
+						{{ range .Members }}
+							{{if eq .Name $title}}
+								{{ if .Icon }}
+								<img class = "member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">
+								{{ end }}
+							{{ end }}
+						{{ end }}
+					{{ end }}	
+					{{ .Title }}
+				</a>
+				{{end}}
+			{{- end }}
 		{{- end }}
-		{{- end }}
-		{{- end }}
-
+		
 	</span>
 </div>
 {{- end }}

--- a/layouts/partials/post_meta/members.html
+++ b/layouts/partials/post_meta/members.html
@@ -2,29 +2,36 @@
 {{- $taxo := "authors" -}}
 {{- with .Param $taxo -}}
 <div class="meta__item-author meta__item">
+	<!--
+	{{- partial "svg/author.svg" (dict "class" "meta__icon") -}}
+	-->
 	<span class="meta__text">
 
 		{{- range $index, $author := . }}
-		{{- if gt $index 0 }}  {{ end -}}
-		{{- $url := urls.Parse ($author | urlize) -}}
-		{{- $path := $url.Path -}}
-		{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path) }}
-		{{- $term := .Data.Term -}}
-		<a class="meta__link" href="{{ .RelPermalink }}" rel="category">
-			{{- range hugo.Data.member }}
-			{{- range .Members }}
-			{{- if eq (lower .Name) (lower $term) }}
-			{{- if .Icon }}
-			<img class="member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">&nbsp;
+			{{- $url := urls.Parse ($author | urlize) -}}
+			{{- $path := $url.Path -}}
+			{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path) }}
+			<!--
+				{{- if gt $index 0 }}, {{ end -}}
+			-->
+				{{ $title := .Title}}
+				{{if ne $index -1}}
+				<a class="meta__link" href="{{ .RelPermalink }}" rel="category">
+					{{ range hugo.Data.member }}
+						{{ range .Members }}
+							{{if eq .Name $title}}
+								{{ if .Icon }}
+								<img class = "member_icon_img" src="{{ .Icon }}" alt="" aria-hidden="true">
+								{{ end }}
+							{{ end }}
+						{{ end }}
+					{{ end }}	
+					{{ .Title }}
+				</a>
+				{{end}}
 			{{- end }}
-			{{- end }}
-			{{- end }}
-			{{- end }}
-			{{- $term -}}
-		</a>
 		{{- end }}
-		{{- end }}
-
+		
 	</span>
 </div>
 {{- end }}

--- a/layouts/taxonomy/author.html
+++ b/layouts/taxonomy/author.html
@@ -1,29 +1,29 @@
 {{ define "main" }}
 <main class="main list" role="main">
 
-	{{ $title := $.Data.Term }}
+	{{ $title := .Title }}
 	{{ $member := hugo.Data.member }}
-
+	
 
 	{{- with .Title }}
 	<header class="main__header">
 		<h1 class="main__title">
-
+			
 			<!--
 				{{- partial "svg/author.svg" (dict "class" "meta__icon") -}}
 			-->
 
 			{{ range $member }}
 				{{ range .Members }}
-					{{ if eq .Name $.Data.Term }}
+					{{ if eq .Name $title }}
 						{{ if .Icon}}
 							<img class = "author_icon_img" src="{{.Icon}}" alt="">
 						{{ end }}
 					{{ end }}
 				{{ end }}
 			{{ end }}
-
-			{{ $.Data.Term }}
+	
+			{{ . }}
 		</h1>
 	</header>
 	{{- end }}


### PR DESCRIPTION
## 概要

- Hugoに先頭強制大文字を切るオプションがあった、のでそれで再対処した
  - 参考：https://gohugo.io/configuration/all/#capitalizelisttitles
- 昔の #344 はリバートした

## 写真

前回のPRだとブラウザタイトルまで対処できていなかった

- <img width="500" alt="image" src="https://github.com/user-attachments/assets/fdfa8d03-2479-4d20-91ef-794d52ee2d13" />
